### PR TITLE
Move activities list to separate activities.json file

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,8 +1,9 @@
 {
-  "servers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
-    }
-  }
+	"servers": {
+		"github": {
+			"type": "http",
+			"url": "https://api.githubcopilot.com/mcp/"
+		},
+	},
+	"inputs": []
 }

--- a/src/activities.json
+++ b/src/activities.json
@@ -1,0 +1,56 @@
+{
+  "Chess Club": {
+    "description": "Learn strategies and compete in chess tournaments",
+    "schedule": "Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 12,
+    "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+  },
+  "Programming Class": {
+    "description": "Learn programming fundamentals and build software projects",
+    "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+    "max_participants": 20,
+    "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+  },
+  "Gym Class": {
+    "description": "Physical education and sports activities",
+    "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+    "max_participants": 30,
+    "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+  },
+  "Soccer Team": {
+    "description": "Join the school soccer team and compete in matches",
+    "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+    "max_participants": 22,
+    "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+  },
+  "Basketball Team": {
+    "description": "Practice and play basketball with the school team",
+    "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+  },
+  "Art Club": {
+    "description": "Explore your creativity through painting and drawing",
+    "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+  },
+  "Drama Club": {
+    "description": "Act, direct, and produce plays and performances",
+    "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+    "max_participants": 20,
+    "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+  },
+  "Math Club": {
+    "description": "Solve challenging problems and participate in math competitions",
+    "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+    "max_participants": 10,
+    "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+  },
+  "Debate Team": {
+    "description": "Develop public speaking and argumentation skills",
+    "schedule": "Fridays, 4:00 PM - 5:30 PM",
+    "max_participants": 12,
+    "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+  }
+}

--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -19,63 +20,14 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+# Load activities from JSON file
+def load_activities():
+    """Load activities from activities.json"""
+    activities_file = os.path.join(Path(__file__).parent, "activities.json")
+    with open(activities_file, 'r') as f:
+        return json.load(f)
+
+activities = load_activities()
 
 
 @app.get("/")


### PR DESCRIPTION
## Description
This PR implements issue #3 by moving the activities list from the hardcoded Python dictionary in `app.py` to a separate `activities.json` file.

## Changes
- Created `src/activities.json` containing all activity data with the same structure
- Updated `src/app.py` to load activities from the JSON file using a `load_activities()` function
- Removed the hardcoded activities dictionary from app.py

## Benefits
- Teachers and non-technical staff can now easily modify activities without fear of breaking the Python code
- Activities data is now separated from application logic
- JSON format is more accessible for non-developers

## Testing
The API functionality remains unchanged - all endpoints work exactly as before:
- `GET /activities` - Returns the list of activities from the JSON file
- `POST /activities/{activity_name}/signup` - Sign up functionality works as before
- `DELETE /activities/{activity_name}/unregister` - Unregister functionality works as before

Closes #3